### PR TITLE
Creates the first webserver dockerfile version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS fira-server-webserver-build-env
+WORKDIR /app
+
+COPY fira-server.csproj ./
+RUN dotnet restore
+
+COPY . ./
+RUN dotnet publish -o build
+
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
+WORKDIR /app
+EXPOSE 5000
+ENV ASPNETCORE_URLS=http://+:5000
+COPY --from=fira-server-webserver-build-env /app/build .
+ENTRYPOINT [ "dotnet", "fira-server.dll" ]


### PR DESCRIPTION
## Description:
Stablishes a initial dockerfile for the webserver service capable of building and running a 'hello world' dotnet webapi project.

## Details:
The dockerfile is divided in two steps. The firs one is based on the
dotnet sdk base image and is used to build and publish the application.
The artifacts resultant of this phase are stored on the `build` directory.

The second step, that uses a runtime only base image, exposes the
necessary network ports, copy the build artifacts from the previus step
results directory, define the url that should be watched by the web
server through a environment variable and starts the application.