### PR TITLE
11 configure a nginx container to work as a reverse proxy

### DIFF
--- a/Infra/Application/Dockerfile.dev
+++ b/Infra/Application/Dockerfile.dev
@@ -18,8 +18,7 @@ ENV Kestrel__Certificates__Default__Path=/etc/ssl/cert/dev-cert.pfx
 ENV Kestrel__Certificates__Default__Password=S56Ojm
 
 COPY --from=fira-server-webserver-build-env /app/build .
-ENV ASPNETCORE_URLS=http://+:5000;https://+:5001
+ENV ASPNETCORE_URLS=http://+:5000
+ENV ASPNETCORE_ENVIRONMENT=Development
 
-EXPOSE 5000
-EXPOSE 5001
 ENTRYPOINT [ "dotnet", "fira-server.dll" ]

--- a/Infra/Nginx/Configs/VHosts/fira-server-dev.conf
+++ b/Infra/Nginx/Configs/VHosts/fira-server-dev.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+    server_name server.fira.com;
+    location / {
+        proxy_pass         http://application:5000;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection keep-alive;
+        proxy_set_header   Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}

--- a/Infra/Nginx/Dockerfile.dev
+++ b/Infra/Nginx/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM nginx:1.23.0
+
+COPY ./Infra/Nginx/Configs/VHosts/fira-server-dev.conf /etc/nginx/conf.d/fira-server-dev.conf

--- a/Program.cs
+++ b/Program.cs
@@ -1,22 +1,32 @@
+using System.Net;
+using Microsoft.AspNetCore.HttpOverrides;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 
 builder.Services.AddControllers();
+builder.Services.Configure<ForwardedHeadersOptions>(options => {
+    options.KnownProxies.Add(Dns.GetHostEntry("reverse-proxy").AddressList[0] );
+});
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
+ForwardedHeadersOptions forwardedHeadersOptions = new ForwardedHeadersOptions {
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+};
+app.UseForwardedHeaders(forwardedHeadersOptions);
+
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
+if (app.Environment.IsDevelopment()) {
     app.UseSwagger();
     app.UseSwaggerUI();
+} else {
+    app.UseHttpsRedirection();
 }
-
-app.UseHttpsRedirection();
 
 app.UseAuthorization();
 

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,23 @@ services:
     build: 
       context: ./
       dockerfile: ./Infra/Application/Dockerfile.dev
-    ports:
-      - "5001:5001"
-      - "5000:5000"
     depends_on:
-      - postgres
-  postgres:
-    image: dev/vind-software/fira-server/postgres:0.2
+      - relational-db
+      - reverse-proxy
+  relational-db:
+    image: dev/vind-software/fira-server/relational-db:0.2
     build: 
       context: ./
       dockerfile: ./Infra/Postgres/Dockerfile.dev
+    ports:
+      - "5432:5432"
+  reverse-proxy:
+    image: dev/vind-software/fira-server/reverse-proxy:0.2
+    build: 
+      context: ./
+      dockerfile: ./Infra/Nginx/Dockerfile.dev
+    ports:
+      - "80:80"
+networks:
+  default:
+    name: fira-server-dev-network

--- a/fira-server.csproj
+++ b/fira-server.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>fira_server</RootNamespace>
+    <UseAppHost>False</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 ## What was done
- On the app dockerfile, the aspnetcore_urls env var was altered to remove the https url pattern. This was done because the communication between the reverse proxy and the application will happen only through http. 
- Also on the app dockerfile, a env var was added to explicitly define the environment as 'Development'.
-  The launchSettings.json also got its applicationUrl attribute updated to only deal with http requests.
-  The property UseAppHost was set to false on the project file to prevent platform specific executables to be generated during the publishing of the app.

- A dockerfile was generated for the nginx container, alongside with the configuration file for a virtualhost. 
- The docker compose was updated with the new service and the default network received a name configuration.
-  On the application startup routine, a new middleware was added: the Microsoft's FowardedHeaders. This middleware restores the headers schema that was altered by the reverse proxy. 
- Along with this change, the https redirect middleware was disabled on the dev environment. This will probably be disabled on production too, hence the use of a reverse proxy, but it is enough for now.