### PR TITLE
Creates the initial institution database structure

### DIFF
--- a/infra/DB/Relational/Scripts/baseline.sql
+++ b/infra/DB/Relational/Scripts/baseline.sql
@@ -1,5 +1,7 @@
 CREATE SCHEMA application; 
 
+COMMENT ON SCHEMA application IS 'Holds application level configuration and utility tables';
+
 CREATE TABLE application.schema_change_log (
     "id" SERIAL PRIMARY KEY,
     "databaseVersion" VARCHAR(10) UNIQUE NOT NULL,

--- a/infra/DB/Relational/Scripts/sc-00.00.0002.json
+++ b/infra/DB/Relational/Scripts/sc-00.00.0002.json
@@ -1,0 +1,6 @@
+{
+    "author":"Guilherme-mm",
+    "application-version":"00.00.001",
+    "creation-date":"2022-09-27",
+    "description":"Creates the initial structure to hold institutions data. Initializes the default institution."
+}

--- a/infra/DB/Relational/Scripts/sc-00.00.0002.sql
+++ b/infra/DB/Relational/Scripts/sc-00.00.0002.sql
@@ -5,8 +5,10 @@ COMMENT ON SCHEMA service IS 'Holds utilitary tables that dont map directly to d
 CREATE TABLE IF NOT EXISTS service.institutions (
     id SERIAL NOT NULL,
     name character varying(150) NOT NULL,
-    ownerName character varying(150) DEFAULT 'Not Informed',
+    "ownerName" character varying(150) DEFAULT 'Not Informed',
     CONSTRAINT institutions_pkey PRIMARY KEY (id)
 );
 
 COMMENT ON TABLE service.institutions IS 'Holds information about the entity ''Institution''';
+
+INSERT INTO service.institutions(id, name, "ownerName") VALUES (0, 'FIRA Server Default', 'Vind Software');

--- a/infra/DB/Relational/Scripts/sc-00.00.0002.sql
+++ b/infra/DB/Relational/Scripts/sc-00.00.0002.sql
@@ -1,0 +1,12 @@
+CREATE SCHEMA IF NOT EXISTS service;
+
+COMMENT ON SCHEMA service IS 'Holds utilitary tables that dont map directly to domain entities';
+
+CREATE TABLE IF NOT EXISTS service.institutions (
+    id SERIAL NOT NULL,
+    name character varying(150) NOT NULL,
+    ownerName character varying(150) DEFAULT 'Not Informed',
+    CONSTRAINT institutions_pkey PRIMARY KEY (id)
+);
+
+COMMENT ON TABLE service.institutions IS 'Holds information about the entity ''Institution''';


### PR DESCRIPTION
## Changes Made
This PR creates a new table, schema and row on the database installation scripts. The new `service` schema was created to hold tables that are not directly related to business domain entities. On this schema, the table `institutions` was created. 

As part of the new schema changing scripts, an insert was made to guarantee the existence of the default institution. 

## The proposed institutions table structure
| Column    | Type              | Size | Constraints | Comment |
|-----------|-------------------|------|-------------|---------|
| id        | SERIAL            | -    | PRIMARY KEY | -       |
| name      | character varying | 150  | NOT NULL    | -       |
| ownerName | character varying | 150  | -           | -       |

## Closing issues
closes #20 
closes #21 