### PR TITLE
Enables debug and hot-reload on the dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,20 @@ services:
       FIRASERVER_DB__Relational__Database: ${FIRASERVER_DB__Relational__Database}
       FIRASERVER_DB__Relational__Username: ${FIRASERVER_DB__Relational__Username}
       FIRASERVER_DB__Relational__Password: ${FIRASERVER_DB__Relational__Password}
+    volumes:
+        - ./src:/app
+        - /app/Api/obj/ 
+        - /app/Api/bin/
+        - /app/Application/obj/ 
+        - /app/Application/bin/
+        - /app/Core/Domain/obj/ 
+        - /app/Core/Domain/bin/
+        - /app/Core/Service/obj/ 
+        - /app/Core/Service/bin/
+        - /app/DI/obj/ 
+        - /app/DI/bin/
+        - /app/Infra/Dal/obj/ 
+        - /app/Infra/Dal/bin/
 
   relational-db:
     image: dev/vind-software/fira-server/relational-db:00.00.001

--- a/infra/Images/Application/Dockerfile.dev
+++ b/infra/Images/Application/Dockerfile.dev
@@ -2,26 +2,20 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0 AS fira-server-webserver-build-env
 WORKDIR /app
 
 # COPY fira-server.csproj ./
-COPY ./src ./
-RUN dotnet restore
+# COPY ./src ./
+# RUN dotnet restore
 
 # COPY ./src ./
-RUN dotnet publish -o build
+#RUN dotnet publish -o build
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
-WORKDIR /app
+# FROM mcr.microsoft.com/dotnet/aspnet:6.0
+# WORKDIR /app
 
-# Copying the development self signed ssl certificate, in order to enable https on the dev env. 
-# COPY ./dev-cert.pfx /etc/ssl/cert/
-# If the permissions 
-# RUN chmod 755 /etc/ssl/cert/dev-cert.pfx
-# ENV Kestrel__Certificates__Default__Path=/etc/ssl/cert/dev-cert.pfx
-# ENV Kestrel__Certificates__Default__Password=S56Ojm
-
-COPY --from=fira-server-webserver-build-env /app/build .
+# COPY --from=fira-server-webserver-build-env /app/build .
 ENV ASPNETCORE_URLS=http://+:5000
 ENV ASPNETCORE_ENVIRONMENT=Development
 
 ENV FIRASERVER_DB__Relational__Host=relational-db
 
-ENTRYPOINT [ "dotnet", "FiraServer.Api.dll" ]
+# ENTRYPOINT [ "dotnet", "FiraServer.Api.dll" ]
+ENTRYPOINT ["dotnet", "watch", "run", "--project=Api/FiraServer.api.csproj", "--urls=http://*:5000"]

--- a/src/FiraServer.sln
+++ b/src/FiraServer.sln
@@ -5,6 +5,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{98AEA857-7052-48E6-A803-1B53D24629C6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FiraServer.Api", "Api\FiraServer.Api.csproj", "{091712D3-EAF6-418A-99A4-3FB58815FD04}"
+	ProjectSection(ProjectDependencies) = postProject
+		{16B1224D-185B-4623-9958-EB1C6A8937CC} = {16B1224D-185B-4623-9958-EB1C6A8937CC}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FiraServer.Application", "Application\FiraServer.Application.csproj", "{16B1224D-185B-4623-9958-EB1C6A8937CC}"
 EndProject

--- a/src/api/Middlewares/Authorization/Oauth2Middleware.cs
+++ b/src/api/Middlewares/Authorization/Oauth2Middleware.cs
@@ -1,7 +1,5 @@
-using FiraServer.Application.Interfaces.Auth;
-using FiraServer.Application.Entities.Auth;
 using FiraServer.api.Common.Exceptions;
-using System.Web;
+using FiraServer.Application.Entities.Auth;
 using FiraServer.Application.Services.Auth;
 
 namespace FiraServer.api.Middlewares.Authorization


### PR DESCRIPTION
## Changes
- Alters the web application dockerfile in order for it to execute the application through `dotnet watch` instead of  `dotnet publish` and `dotnet run`. This change enables hot-reload features and the attachment of debbugers. The dockerfile also was changed to be based on a single phase, using the dotnet sdk image. The source code is not copied to the container anymore, as the source code is now shared between host and container through a volume.
- On the docker compose file, multiple volumes are created for the application container. One of them is used to map the src folder to the /app on the container. The other ones are a workaround to prevent dotnet specific folders to be shared between host and container, as this was causing many referencing problems when using visual studio

## Comments
From initial tests, is now possible to fully debug the application. To do that, is necessary to attach to the service inside the container. This process is still manual and would be nice to automate this when clicking on the launch button of the visual studio. The necessary changes to enable debugging also enabled hot-reload features, very useful for the development.

## Related Issues
closes #28 